### PR TITLE
Reorganize events: move Dub Unit to top, add past events

### DIFF
--- a/client/components/ui/card.tsx
+++ b/client/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "rounded-xl border border-red-600/20 bg-[#0e0e11] bg-gradient-to-br from-red-600/5 to-green-500/5 text-card-foreground shadow-sm transition-shadow",
       className,
     )}
     {...props}
@@ -60,7 +60,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  <div ref={ref} className={cn("p-6", className)} {...props} />
 ));
 CardContent.displayName = "CardContent";
 

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -279,7 +279,10 @@ export default function Index() {
                           {show.event && (
                             <div className="text-lg font-bold text-primary mb-1">
                               {new Date(show.date) < new Date() ? (
-                                <p>{show.event} - Already Happened... You Missed it!</p>
+                                <p>
+                                  {show.event} - Already Happened... You Missed
+                                  it!
+                                </p>
                               ) : (
                                 show.event
                               )}

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -278,7 +278,11 @@ export default function Index() {
                         <div className="flex-1">
                           {show.event && (
                             <div className="text-lg font-bold text-primary mb-1">
-                              {show.event}
+                              {new Date(show.date) < new Date() ? (
+                                <p>{show.event} - Already Happened... You Missed it!</p>
+                              ) : (
+                                show.event
+                              )}
                             </div>
                           )}
                           <h3 className="font-semibold text-lg">
@@ -301,24 +305,28 @@ export default function Index() {
                         )}
                       </div>
                     </div>
-                    <Button className="shrink-0" asChild>
-                      <a
-                        href={show.ticketLink}
-                        target={
-                          show.ticketLink.startsWith("http")
-                            ? "_blank"
-                            : undefined
-                        }
-                        rel={
-                          show.ticketLink.startsWith("http")
-                            ? "noopener noreferrer"
-                            : undefined
-                        }
-                      >
-                        <ExternalLink className="w-4 h-4 mr-2" />
-                        Get Tickets
-                      </a>
-                    </Button>
+                    {show.ticketLink &&
+                      show.ticketLink !== "#" &&
+                      new Date(show.date) >= new Date() && (
+                        <Button className="shrink-0" asChild>
+                          <a
+                            href={show.ticketLink}
+                            target={
+                              show.ticketLink.startsWith("http")
+                                ? "_blank"
+                                : undefined
+                            }
+                            rel={
+                              show.ticketLink.startsWith("http")
+                                ? "noopener noreferrer"
+                                : undefined
+                            }
+                          >
+                            <ExternalLink className="w-4 h-4 mr-2" />
+                            Get Tickets
+                          </a>
+                        </Button>
+                      )}
                   </div>
                 </CardContent>
               </Card>

--- a/client/pages/Live.tsx
+++ b/client/pages/Live.tsx
@@ -1,51 +1,137 @@
 import Layout from "@/components/Layout";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Calendar, MapPin, ExternalLink, Clock } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Calendar, MapPin, ExternalLink } from "lucide-react";
+
+interface EventItem {
+  id: string;
+  date: string; // ISO yyyy-mm-dd
+  event: string;
+  venue: string;
+  city: string;
+  ticketLink?: string;
+  supportingActs?: string;
+  description?: string;
+  badge?: string;
+  poster?: string;
+}
 
 export default function Live() {
-  const upcomingShows = [
+  const events: EventItem[] = [
     {
-      id: "featured",
-      date: "2024-10-10",
+      id: "dub-unit",
+      date: "2025-10-10",
+      event: "Dub Unit",
       venue: "Het Depot & Kingstep",
       city: "Leuven, Belgium",
-      ticketLink: "https://www.hetdepot.be",
-      time: "TBA",
-      status: "On Sale",
-      featured: true,
-      event: "Dub Unit",
+      ticketLink:
+        "https://apps.ticketmatic.com/widgets/hetdepot/flow/feest?event=697505918189&l=en#!/addtickets",
       supportingActs: "w/ Macka B & The Roots Ragga Band, Reemshot",
-      poster: "https://cdn.builder.io/api/v1/image/assets%2F76e39d6cb5b24501bed5149204e569f5%2F95089408cefb4dd5898cd1de43b15593?format=webp&width=800"
+      poster:
+        "https://cdn.builder.io/api/v1/image/assets%2F76e39d6cb5b24501bed5149204e569f5%2F95089408cefb4dd5898cd1de43b15593?format=webp&width=800",
     },
     {
-      id: "1",
-      date: "2024-11-15",
-      venue: "Reggae Cafe",
-      city: "Amsterdam, Netherlands",
-      ticketLink: "#",
-      time: "9:00 PM",
-      status: "On Sale",
-    },
-    {
-      id: "2",
-      date: "2024-11-22",
-      venue: "Dub Club",
-      city: "London, UK",
-      ticketLink: "#",
-      time: "8:00 PM",
-      status: "Pre-Sale",
-    },
-    {
-      id: "3",
-      date: "2024-12-01",
-      venue: "Rasta Foundation",
-      city: "Berlin, Germany",
-      ticketLink: "#",
-      time: "9:30 PM",
-      status: "On Sale",
+      id: "rootsrev",
+      date: "2025-09-27",
+      event: "Rootsrev Soundsystem",
+      venue: "Festa Campestre",
+      city: "Vidulis, UD, Italy",
+      description:
+        "Featuring: Angus Digital - The Dub Alchemist, Militant Youths (from Genova)",
+      badge: "For the First Time to the World",
+      poster:
+        "https://cdn.builder.io/api/v1/image/assets%2F76e39d6cb5b24501bed5149204e569f5%2F8bbffc1ee721405e975dc3ade0cfe021?format=webp&width=800",
     },
   ];
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const toDate = (s: string) => {
+    const d = new Date(s + "T00:00:00");
+    d.setHours(0, 0, 0, 0);
+    return d;
+  };
+  const formatLong = (s: string) =>
+    new Date(s).toLocaleDateString("en-US", {
+      weekday: "long",
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+    });
+
+  const upcoming = events
+    .filter((e) => toDate(e.date) >= today)
+    .sort((a, b) => toDate(a.date).getTime() - toDate(b.date).getTime());
+  const past = events
+    .filter((e) => toDate(e.date) < today)
+    .sort((a, b) => toDate(b.date).getTime() - toDate(a.date).getTime());
+
+  const renderCard = (e: EventItem) => (
+    <Card
+      key={e.id}
+      className="max-w-4xl mx-auto bg-gradient-to-br from-red-600/10 to-green-500/10 border-red-600/20 mb-16"
+    >
+      <CardContent className="p-8">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-center">
+          <div className="order-2 lg:order-1">
+            <div>
+              <div className="text-primary font-bold text-xl mb-2">
+                {formatLong(e.date)}
+              </div>
+              <h3 className="text-3xl font-bold mb-2">{e.event}</h3>
+              <div className="text-xl font-semibold mb-2">{e.venue}</div>
+              <div className="flex items-center text-muted-foreground mb-2">
+                <MapPin className="w-5 h-5 mr-2" />
+                {e.city}
+              </div>
+              {e.supportingActs && (
+                <div className="text-lg text-muted-foreground mb-4">
+                  {e.supportingActs}
+                </div>
+              )}
+              {e.description && (
+                <div className="text-lg text-muted-foreground mb-4">
+                  <span className="font-semibold">Featuring:</span>
+                  <br />
+                  {e.description}
+                </div>
+              )}
+              {e.badge && (
+                <div className="mb-4">
+                  <span className="px-3 py-2 rounded-full text-sm font-medium bg-accent/20 text-accent">
+                    {e.badge}
+                  </span>
+                </div>
+              )}
+              {e.ticketLink && toDate(e.date) >= today && (
+                <div className="flex gap-4">
+                  <Button
+                    size="lg"
+                    className="bg-gradient-to-r from-red-600 via-yellow-400 to-green-500 text-black"
+                    asChild
+                  >
+                    <a href={e.ticketLink} target="_blank" rel="noopener noreferrer">
+                      <ExternalLink className="w-5 h-5 mr-2" />
+                      <div className="text-black">Get Tickets</div>
+                    </a>
+                  </Button>
+                </div>
+              )}
+            </div>
+          </div>
+          <div className="order-1 lg:order-2">
+            {e.poster && (
+              <img
+                src={e.poster}
+                alt={`${e.event} Event Poster`}
+                className="w-full max-w-md mx-auto rounded-lg shadow-2xl border-2 border-primary/30"
+              />
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
 
   return (
     <Layout>
@@ -53,99 +139,23 @@ export default function Live() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
             <Calendar className="w-16 h-16 mx-auto mb-6 text-primary" />
-            <h1 className="text-4xl font-bold mb-4"><p>Live Dates</p></h1>
+            <h1 className="text-4xl font-bold mb-4">
+              <p>Live Dates</p>
+            </h1>
             <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
               Catch Angus Digital live at these upcoming venues. Experience the full energy
               of dub and reggae fusion in person.
             </p>
           </div>
 
-          {/* First Featured Show - BUSSOLINO */}
-          <div className="mb-16">
-            <Card className="max-w-4xl mx-auto bg-gradient-to-br from-red-600/10 to-green-500/10 border-red-600/20">
-              <CardContent className="p-8">
-                <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-center">
-                  <div className="order-2 lg:order-1">
-                    <div>
-                      <div className="text-primary font-bold text-xl mb-2">
-                        Saturday, September 27, 2025
-                      </div>
-                      <h3 className="text-3xl font-bold mb-2"><p>Rootsrev Soundsystem</p></h3>
-                      <div className="text-xl font-semibold mb-2">Festa Campestre</div>
-                      <div className="flex items-center text-muted-foreground mb-2">
-                        <MapPin className="w-5 h-5 mr-2" />
-                        Vidulis, UD, Italy
-                      </div>
-                      <div className="text-lg text-muted-foreground mb-4">
-                        <span className="font-semibold">Featuring:</span><br />
-                        <p>Angus Digital - The Dub Alchemist</p><br />
-                        Militant Youths (from Genova)
-                      </div>
-                      <div className="mb-4">
-                        <span className="px-3 py-2 rounded-full text-sm font-medium bg-accent/20 text-accent">
-                          For the First Time to the World
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                  <div className="order-1 lg:order-2">
-                    <img
-                      src="https://cdn.builder.io/api/v1/image/assets%2F76e39d6cb5b24501bed5149204e569f5%2F8bbffc1ee721405e975dc3ade0cfe021?format=webp&width=800"
-                      alt="BUSSOLINO Event Poster"
-                      className="w-full max-w-md mx-auto rounded-lg shadow-2xl border-2 border-primary/30"
-                    />
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
+          {upcoming.map(renderCard)}
 
-          {/* Second Featured Show - Dub Unit */}
-          <div className="mb-16">
-            <Card className="max-w-4xl mx-auto bg-gradient-to-br from-red-600/10 to-green-500/10 border-red-600/20">
-              <CardContent className="p-8">
-                <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 items-center">
-                  <div className="order-2 lg:order-1">
-                    <div>
-                      <div className="text-primary font-bold text-xl mb-2">
-                        Thursday, October 10, 2024
-                      </div>
-                      <h3 className="text-3xl font-bold mb-2">Dub Unit</h3>
-                      <div className="text-xl font-semibold mb-2">Het Depot & Kingstep</div>
-                      <div className="flex items-center text-muted-foreground mb-2">
-                        <MapPin className="w-5 h-5 mr-2" />
-                        Leuven, Belgium
-                      </div>
-                      <div className="text-lg text-muted-foreground mb-4">
-                        w/ Macka B & The Roots Ragga Band, Reemshot
-                      </div>
-                      <div className="flex gap-4">
-                        <Button size="lg" className="bg-gradient-to-r from-red-600 via-yellow-400 to-green-500 text-black" asChild>
-                          <a href="https://apps.ticketmatic.com/widgets/hetdepot/flow/feest?event=697505918189&l=en#!/addtickets" target="_blank" rel="noopener noreferrer">
-                            <ExternalLink className="w-5 h-5 mr-2" />
-                            <div className="text-black">Get Tickets</div>
-                          </a>
-                        </Button>
-                        <Button size="lg" variant="outline" asChild>
-                          <a href="https://www.hetdepot.be/over-het-depot" target="_blank" rel="noopener noreferrer">
-                            <MapPin className="w-5 h-5 mr-2" />
-                            Venue Info
-                          </a>
-                        </Button>
-                      </div>
-                    </div>
-                  </div>
-                  <div className="order-1 lg:order-2">
-                    <img
-                      src="https://cdn.builder.io/api/v1/image/assets%2F76e39d6cb5b24501bed5149204e569f5%2F95089408cefb4dd5898cd1de43b15593?format=webp&width=800"
-                      alt="Dub Unit Event Poster"
-                      className="w-full max-w-md mx-auto rounded-lg shadow-2xl border-2 border-primary/30"
-                    />
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
-          </div>
+          {past.length > 0 && (
+            <div className="mt-8">
+              <h2 className="text-3xl font-bold mb-6">Past Events</h2>
+              {past.map(renderCard)}
+            </div>
+          )}
         </div>
       </div>
     </Layout>

--- a/client/pages/Live.tsx
+++ b/client/pages/Live.tsx
@@ -110,7 +110,11 @@ export default function Live() {
                     className="bg-gradient-to-r from-red-600 via-yellow-400 to-green-500 text-black"
                     asChild
                   >
-                    <a href={e.ticketLink} target="_blank" rel="noopener noreferrer">
+                    <a
+                      href={e.ticketLink}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
                       <ExternalLink className="w-5 h-5 mr-2" />
                       <div className="text-black">Get Tickets</div>
                     </a>
@@ -143,8 +147,8 @@ export default function Live() {
               <p>Live Dates</p>
             </h1>
             <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-              Catch Angus Digital live at these upcoming venues. Experience the full energy
-              of dub and reggae fusion in person.
+              Catch Angus Digital live at these upcoming venues. Experience the
+              full energy of dub and reggae fusion in person.
             </p>
           </div>
 


### PR DESCRIPTION
## Purpose
The user requested to reorganize the events display to prioritize upcoming shows and better organize past events. Specifically, they wanted to move "Dub Unit" to the top as it's the next show and create a separate "Past Events" section for events like "Rootsrev" that have already occurred.

## Code changes
- **Event reordering**: Restructured events array to prioritize Dub Unit (2025-10-10) over Rootsrev (2025-09-27) based on upcoming status
- **Past events section**: Added logic to separate past and upcoming events with dedicated "Past Events" section
- **Date filtering**: Implemented date comparison logic to automatically categorize events as past or upcoming
- **Event status indicators**: Added "Already Happened... You Missed it!" message for past events in Index.tsx
- **Conditional ticket buttons**: Hide ticket purchase buttons for past events and invalid ticket links
- **Card styling updates**: Enhanced card appearance with gradient backgrounds and improved border styling
- **Content padding adjustments**: Removed top padding from CardContent component

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d766c224bdf14b5eb0e84da531e277bf/pixel-sanctuary)

👀 [Preview Link](https://d766c224bdf14b5eb0e84da531e277bf-pixel-sanctuary.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d766c224bdf14b5eb0e84da531e277bf</projectId>-->
<!--<branchName>pixel-sanctuary</branchName>-->